### PR TITLE
Implement user-defined operator precedence

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
     "files.watcherExclude": {
         "**/target": true
     },
-    "search.usePCRE2": true
+    "search.usePCRE2": true,
+    "files.exclude": {
+        "**/.git": false,
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
     "files.watcherExclude": {
         "**/target": true
     },
-    "editor.formatOnSave": true,
     "search.usePCRE2": true
 }

--- a/README.md
+++ b/README.md
@@ -41,21 +41,55 @@ The repository can be downloaded using Git:
 git clone https://github.com/Charles-Johnson/zia_programming.git
 ```
 
-### Building The Libraries
 
-To build all members in debug mode, simply use the command
+# Testing
 
-```
-cargo build
-```
-
-To run tests:
-
-```
+To test all non-ignored tests:
+```bash
 cargo test
 ```
 
-To optimise runtime performance at the cost of compilation time, append `--release` to the above commands.
+To test all tests in the documentation:
+```bash
+cargo test --doc
+```
+
+To test a specific test:
+```bash
+cargo test specific_test
+```
+
+To run a set of integration tests:
+```bash
+cargo test --test integration_test_filename
+```
+
+# Documentation
+
+To generate API documentation:
+```bash
+cargo doc
+```
+You can then view `./target/doc/zia/index.html` in a web browser
+
+To generate internal documentation:
+```bash
+cargo doc --document-private-items
+```
+
+# Releasing New Versions
+In `./Cargo.toml`:
+```toml
+[package]
+version = x.y.z
+```
+Then run in the terminal the following
+```bash
+git commit -a -m "Releasing zia-x.y.z"
+git tag -a zia-x.y.z HEAD
+cargo package
+cargo publish
+```
 
 ## License
 

--- a/test_zia/src/lib.rs
+++ b/test_zia/src/lib.rs
@@ -64,6 +64,7 @@ lazy_static! {
         cs.insert("right".to_string());
         cs.insert("left".to_string());
         cs.insert(">-".to_string());
+        cs.insert("default".to_string());
         cs
     };
 }

--- a/test_zia/src/lib.rs
+++ b/test_zia/src/lib.rs
@@ -62,8 +62,9 @@ lazy_static! {
         cs.insert("assoc".to_string());
         cs.insert("right".to_string());
         cs.insert("left".to_string());
-        cs.insert(">-".to_string());
+        cs.insert("prec".to_string());
         cs.insert("default".to_string());
+        cs.insert(">".to_string());
         cs
     };
 }

--- a/zia/Cargo.toml
+++ b/zia/Cargo.toml
@@ -18,8 +18,10 @@ name = "zia"
 crate-type = ["lib"]
 
 [dependencies]
+lazy_static = "1.2.0"
 maplit = "1.0.2"
 snafu = "0.5.0"
+
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 slog = { version="2.4.1", features=["max_level_info", "release_max_level_warn"]}

--- a/zia/Cargo.toml
+++ b/zia/Cargo.toml
@@ -16,6 +16,7 @@ maintenance = {status = "actively-developed"}
 [lib]
 name = "zia"
 crate-type = ["lib"]
+path = "src/lib.rs"
 
 [dependencies]
 lazy_static = "1.2.0"

--- a/zia/README.md
+++ b/zia/README.md
@@ -8,9 +8,9 @@ The Zia project aims to develop a programming language that can be used to progr
 Instead of storing the source code as plain text and editing the raw text (which can easily break
 the program), the runtime environment of the interpreter (the `Context`) can be saved to disk and
 used in other programs. All the programming is done using an interactive shell such as
-[`IZia`](https://github.com/Charles-Johnson/zia_programming/tree/master/izia) or via an online IDE
-(https://zia-lang.org). The commands sent are interpreted based on the `Context`. They are used to
-incrementally modify, test and debug the `Context`.
+[`IZia`](https://github.com/Charles-Johnson/zia_programming/tree/master/izia) or via an [online IDE](https://zia-lang.org).
+The commands sent are interpreted based on the `Context`. They are used to incrementally modify, test
+and debug the `Context`.
 
 Expressions for Zia commands represent a binary tree where parentheses group a pair of expressions
 and a space separates a pair of expressions. For example `"(ll lr) (rl rr)"` represents a perfect

--- a/zia/README.md
+++ b/zia/README.md
@@ -1,88 +1,105 @@
-# `zia`: Interpreter for the Zia programming language.
+# zia
 
-The Zia project aims to develop a programming language that can be used to program itself. 
-Instead of storing the source code as plain text and editing the raw text (which can easily break 
-the program), the runtime environment of the interpreter (the `Context`) can be saved to disk and 
+## Interpreter for the Zia programming language
+The Zia project aims to develop a programming language that can be used to program itself.
+Instead of storing the source code as plain text and editing the raw text (which can easily break
+the program), the runtime environment of the interpreter (the `Context`) can be saved to disk and
 used in other programs. All the programming is done using an interactive shell such as
-[IZia](https://github.com/Charles-Johnson/zia_programming/tree/master/izia) or via an online IDE 
+[`IZia`](https://github.com/Charles-Johnson/zia_programming/tree/master/izia) or via an online IDE
 (https://zia-lang.org). The commands sent are interpreted based on the `Context`. They are used to
-incrementally modify, test and debug the `Context`.  
+incrementally modify, test and debug the `Context`.
 
-Expressions for Zia commands represent a binary tree where parentheses group a pair of 
-expressions and a space separates a pair of expressions.
+Expressions for Zia commands represent a binary tree where parentheses group a pair of expressions
+and a space separates a pair of expressions. For example `"(ll lr) (rl rr)"` represents a perfect
+binary tree of height 2 with leaves `"ll"`, `"lr"`, `"rl"`, `"rr"` going from left to right.
 
-e.g.
-```
-(ll lr) (rl rr)
-```    
-represents the following binary tree:
-```
-    / \
-   /   \
-  /     \
- / \   / \
-ll lr rl rr
-```
-
-The leaves of the tree can be any unicode string without spaces or parentheses. These symbols may 
+The leaves of the tree can be any unicode string without spaces or parentheses. These symbols may
 be recognised by the intepreter as concepts or if not used to label new concepts.
 
 Currently, only the lowest-level functionality has been implemented. It's important that programs
-are represented consistently and transparently within the `Context` in order to achieve a 
-self-describing system. The syntax shown below may appear awkward but more convenient syntax will 
-be possible once more functionality is added. For example, the need to group pairs of expressions 
+are represented consistently and transparently within the `Context` in order to achieve a
+self-describing system. The syntax shown below may appear awkward but more convenient syntax will
+be possible once more functionality is added. For example, the need to group pairs of expressions
 in parentheses will be alleviated by functionality to set the relative precedence and associativity
-of concepts. 
+of concepts.
 
-# API Documentation
+So far there are 10 built-in concepts. A new `Context` labels these with the symbols, `"label_of"`,
+`"->"`, `":="`, `"let"`, `"true"`, `"false"`, `"assoc"`, `"right"`, `"left"`, "prec", "deafult", ">" but the labels
+can be changed to different symbols for different languages or disciplines.
 
-Please refer to https://docs.rs/zia for documentation of the latest released version of `zia`.
+## Examples
 
-# Testing
+```rust
+extern crate zia;
+use zia::{Context, ZiaError};
 
-To test all non-ignored tests:
-```bash
-cargo test
+// Construct a new `Context` using the `new` method
+let mut context = Context::new();
+
+// Specify operator precedence for `let` and `->`.
+assert_eq!(context.execute("let default > prec ->"), "");
+assert_eq!(context.execute("let (prec ->) > prec let"), "");
+// Cannot yet infer partial order. Requires implication to express transitive property
+assert_eq!(context.execute("let default > prec let"), "");
+
+// Specify the rule that the concept "a b" reduces to concept "c"
+assert_eq!(context.execute("let a b -> c"), "");
+assert_eq!(context.execute("a b"), "c");
+
+// Change the rule so that concept "a b" instead reduces to concept "d"
+assert_eq!(context.execute("let a b -> d"), "");
+assert_eq!(context.execute("a b"), "d");
+
+// Change the rule so "a b" doesn't reduce any further
+assert_eq!(context.execute("let a b -> a b"), "");
+assert_eq!(context.execute("a b"), "a b");
+
+// Try to specify a rule that already exists
+assert_eq!(context.execute("let a b -> a b"), ZiaError::RedundantReduction.to_string());
+assert_eq!(context.execute("let a b -> c"), "");
+assert_eq!(context.execute("let a b -> c"), ZiaError::RedundantReduction.to_string());
+
+// Relabel "label_of" to "표시"
+assert_eq!(context.execute("let 표시 := label_of"), "");
+assert_eq!(context.execute("표시 a b"), "\'c\'");
+
+// You can reduce a labelled concept
+assert_eq!(context.execute("let a -> d"), "");
+
+// Try to specify the composition of a concept in terms of itself
+assert_eq!(context.execute("let b := a b"), ZiaError::InfiniteDefinition.to_string());
+
+// Try to specify the reduction of concept in terms of itself
+assert_eq!(context.execute("let c d -> (c d) e"), ZiaError::ExpandingReduction.to_string());
+
+// Determine the truth of a reduction
+assert_eq!(context.execute("a -> d"), "true");
+assert_eq!(context.execute("d -> a"), "false");
+
+// A concept never reduces to itself
+assert_eq!(context.execute("a -> a"), "false");
+
+// Cannot reduce a reduction expression between unrelated concepts
+assert_eq!(context.execute("d -> f"), "d -> f");
+
+// Can ask whether a reduction is true or false
+assert_eq!(context.execute("(a -> d) -> true"), "true");
+assert_eq!(context.execute("(d -> a) -> false"), "true");
+
+// Let an arbitary symbol be true
+assert_eq!(context.execute("let g"), "");
+assert_eq!(context.execute("g"), "true");
+
+// Let an arbitary expression be true
+assert_eq!(context.execute("let h i j"), "");
+assert_eq!(context.execute("h i j"), "true");
+
+// Determine associativity of symbol
+assert_eq!(context.execute("assoc a"), "right");
+
+// Define patterns
+assert_eq!(context.execute("let _x_ and false -> false"), "");
+assert_eq!(context.execute("foo and false"), "false");
 ```
 
-To test all tests in the documentation:
-```bash
-cargo test --doc
-```
-
-To test a specific test:
-```bash
-cargo test specific_test
-```
-
-To run a set of integration tests:
-```bash
-cargo test --test integration_test_filename
-```
-
-# Documentation
-
-To generate API documentation:
-```bash
-cargo doc
-```
-You can then view `./target/doc/zia/index.html` in a web browser
-
-To generate internal documentation:
-```bash
-cargo doc --document-private-items
-```
-
-# Releasing New Versions
-In `./Cargo.toml`:
-```toml
-[package]
-version = x.y.z
-```
-Then run in the terminal the following
-```bash
-git commit -a -m "Releasing zia-x.y.z"
-git tag -a zia-x.y.z HEAD
-cargo package
-cargo publish
-```
+License: GPL-3.0

--- a/zia/README.md
+++ b/zia/README.md
@@ -1,6 +1,9 @@
 # zia
 
+[![Crates.io](https://img.shields.io/crates/v/zia.svg)](https://crates.io/crates/zia)
+
 ## Interpreter for the Zia programming language
+
 The Zia project aims to develop a programming language that can be used to program itself.
 Instead of storing the source code as plain text and editing the raw text (which can easily break
 the program), the runtime environment of the interpreter (the `Context`) can be saved to disk and

--- a/zia/src/constants.rs
+++ b/zia/src/constants.rs
@@ -24,3 +24,4 @@ pub const ASSOC: usize = 6;
 pub const RIGHT: usize = 7;
 pub const LEFT: usize = 8;
 pub const PRECEDENCE: usize = 9;
+pub const DEFAULT: usize = 10;

--- a/zia/src/context.rs
+++ b/zia/src/context.rs
@@ -46,9 +46,7 @@ impl Context {
     pub fn execute(&mut self, command: &str) -> String {
         #[cfg(not(target_arch = "wasm32"))]
         info!(self.logger, "execute({})", command);
-        let string = self
-            .snap_shot
-            .ast_from_expression(&self.delta, command)
+        let string = dbg!(self.snap_shot.ast_from_expression(&self.delta, command))
             .and_then(|a| self.call(&a))
             .unwrap_or_else(|e| e.to_string());
         #[cfg(not(target_arch = "wasm32"))]
@@ -71,6 +69,7 @@ impl Context {
         };
         let labels = vec![
             "label_of", ":=", "->", "let", "true", "false", "assoc", "right", "left", ">-",
+            "default",
         ];
         let mut counter = 0;
         let concepts: Vec<usize> = from_fn(|| {
@@ -87,6 +86,9 @@ impl Context {
             .zip(&labels)
             .try_for_each(|(concept, string)| self.label(*concept, string))
             .unwrap();
+        self.execute("let (not true) -> false");
+        self.execute("let (not false) -> true");
+        self.execute("let (_x_ >- _y_) -> not _y_ >- _x_");
     }
     fn reduce_and_call_pair(
         &mut self,

--- a/zia/src/context.rs
+++ b/zia/src/context.rs
@@ -50,10 +50,11 @@ impl Context {
     pub fn execute(&mut self, command: &str) -> String {
         #[cfg(not(target_arch = "wasm32"))]
         info!(self.logger, "execute({})", command);
-        let string =
-            dbg!(self.snap_shot.ast_from_expression(&self.delta, command))
-                .and_then(|a| self.call(&a))
-                .unwrap_or_else(|e| e.to_string());
+        let string = self
+            .snap_shot
+            .ast_from_expression(&self.delta, command)
+            .and_then(|a| self.call(&a))
+            .unwrap_or_else(|e| e.to_string());
         #[cfg(not(target_arch = "wasm32"))]
         info!(self.logger, "execute({}) -> {:#?}", command, self.delta);
         self.commit();
@@ -78,7 +79,7 @@ impl Context {
         };
         let labels = vec![
             "label_of", ":=", "->", "let", "true", "false", "assoc", "right",
-            "left", ">-", "default",
+            "left", "prec", "default", ">",
         ];
         let mut counter = 0;
         let concepts: Vec<usize> = from_fn(|| {
@@ -95,9 +96,6 @@ impl Context {
             .zip(&labels)
             .try_for_each(|(concept, string)| self.label(*concept, string))
             .unwrap();
-        self.execute("let (not true) -> false");
-        self.execute("let (not false) -> true");
-        self.execute("let (_x_ >- _y_) -> not _y_ >- _x_");
     }
 
     fn reduce_and_call_pair(

--- a/zia/src/context.rs
+++ b/zia/src/context.rs
@@ -55,7 +55,10 @@ impl Context {
             .ast_from_expression(&self.delta, command)
             .and_then(|a| {
                 #[cfg(not(target_arch = "wasm32"))]
-                info!(self.logger, "ast_from_expression({}) -> {:#?}", command, a);
+                info!(
+                    self.logger,
+                    "ast_from_expression({}) -> {:#?}", command, a
+                );
                 self.call(&a)
             })
             .unwrap_or_else(|e| e.to_string());

--- a/zia/src/context.rs
+++ b/zia/src/context.rs
@@ -254,7 +254,7 @@ impl Context {
                     } else {
                         Err(ZiaError::CannotReduceFurther)
                     }
-                }
+                },
             },
             None => Err(ZiaError::UnusedSymbol),
         }
@@ -295,27 +295,27 @@ impl Context {
                     } else {
                         self.relabel(b, &new.to_string())
                     }
-                }
+                },
                 (None, None, Some((ref left, ref right))) => {
                     self.define_new_syntax(&new.to_string(), left, right)
-                }
+                },
                 (Some(a), Some(b), None) => {
                     if a == b {
                         self.cleanly_delete_definition(a)
                     } else {
                         Err(ZiaError::DefinitionCollision)
                     }
-                }
+                },
                 (Some(a), Some(b), Some(_)) => {
                     if a == b {
                         Err(ZiaError::RedundantDefinition)
                     } else {
                         Err(ZiaError::DefinitionCollision)
                     }
-                }
+                },
                 (Some(a), None, Some((ref left, ref right))) => {
                     self.redefine(a, left, right)
-                }
+                },
             }
         }
     }
@@ -340,7 +340,7 @@ impl Context {
                 self.try_delete_concept(concept)?;
                 self.try_delete_concept(left)?;
                 self.try_delete_concept(right)
-            }
+            },
         }
     }
 
@@ -529,7 +529,7 @@ impl Context {
                         self.label(concept, string)?;
                     }
                     Ok(concept)
-                }
+                },
             }
         }
     }
@@ -577,7 +577,7 @@ impl Context {
                     definition, lefthand, righthand, temporary,
                 )?;
                 Ok(definition)
-            }
+            },
             Some(def) => Ok(def),
         }
     }

--- a/zia/src/context.rs
+++ b/zia/src/context.rs
@@ -53,7 +53,11 @@ impl Context {
         let string = self
             .snap_shot
             .ast_from_expression(&self.delta, command)
-            .and_then(|a| self.call(&a))
+            .and_then(|a| {
+                #[cfg(not(target_arch = "wasm32"))]
+                info!(self.logger, "ast_from_expression({}) -> {:#?}", command, a);
+                self.call(&a)
+            })
             .unwrap_or_else(|e| e.to_string());
         #[cfg(not(target_arch = "wasm32"))]
         info!(self.logger, "execute({}) -> {:#?}", command, self.delta);

--- a/zia/src/context.rs
+++ b/zia/src/context.rs
@@ -27,6 +27,7 @@ use slog::{Drain, Logger};
 use snap_shot::SnapShot;
 use std::{default::Default, iter::from_fn, mem::swap, rc::Rc};
 
+#[derive(Clone)]
 pub struct Context {
     snap_shot: SnapShot,
     #[cfg(not(target_arch = "wasm32"))]

--- a/zia/src/context_search.rs
+++ b/zia/src/context_search.rs
@@ -70,10 +70,10 @@ impl<'a> ContextSearch<'a> {
                         .is_none() =>
                 {
                     Some(self.snap_shot.to_ast(self.delta, DEFAULT))
-                }
+                },
                 _ => {
                     self.variable_mask.get(&lc).and_then(|ast| self.reduce(ast))
-                }
+                },
             })
             .or_else(|| {
                 right
@@ -86,6 +86,7 @@ impl<'a> ContextSearch<'a> {
                     .or_else(|| self.recursively_reduce_pair(left, right))
             })
     }
+
     fn recursively_reduce_pair(
         &self,
         left: &Rc<SyntaxTree>,
@@ -121,6 +122,7 @@ impl<'a> ContextSearch<'a> {
             Some(self.snap_shot.contract_pair(self.delta, &l, &r))
         }
     }
+
     fn substitute(&self, ast: &Rc<SyntaxTree>) -> Rc<SyntaxTree> {
         ast.get_concept()
             .and_then(|c| self.variable_mask.get(&c).cloned())
@@ -300,7 +302,7 @@ impl<'a> ContextSearch<'a> {
                         self.snap_shot.to_ast(self.delta, FALSE)
                     }
                 })
-            }
+            },
             _ => None,
         })
     }

--- a/zia/src/lib.rs
+++ b/zia/src/lib.rs
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+//! [![Crates.io](https://img.shields.io/crates/v/zia.svg)](https://crates.io/crates/zia)
+//! 
 //! # Interpreter for the Zia programming language
+//! 
 //! The Zia project aims to develop a programming language that can be used to program itself.
 //! Instead of storing the source code as plain text and editing the raw text (which can easily break
 //! the program), the runtime environment of the interpreter (the `Context`) can be saved to disk and

--- a/zia/src/lib.rs
+++ b/zia/src/lib.rs
@@ -119,6 +119,8 @@
 //! ```
 
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate maplit;
 #[cfg(not(target_arch = "wasm32"))]
 #[macro_use]
@@ -155,3 +157,9 @@ mod snap_shot;
 pub use context::Context;
 
 pub use errors::ZiaError;
+
+// Saves having to construct a new `Context` each time.
+#[macro_export]
+lazy_static! {
+    pub static ref NEW_CONTEXT: Context = Context::new();
+}

--- a/zia/src/lib.rs
+++ b/zia/src/lib.rs
@@ -15,16 +15,16 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! [![Crates.io](https://img.shields.io/crates/v/zia.svg)](https://crates.io/crates/zia)
-//! 
+//!
 //! # Interpreter for the Zia programming language
-//! 
+//!
 //! The Zia project aims to develop a programming language that can be used to program itself.
 //! Instead of storing the source code as plain text and editing the raw text (which can easily break
 //! the program), the runtime environment of the interpreter (the `Context`) can be saved to disk and
 //! used in other programs. All the programming is done using an interactive shell such as
-//! [`IZia`](https://github.com/Charles-Johnson/zia_programming/tree/master/izia) or via an online IDE 
-//! (https://zia-lang.org). The commands sent are interpreted based on the `Context`. They are used to
-//! incrementally modify, test and debug the `Context`.
+//! [`IZia`](https://github.com/Charles-Johnson/zia_programming/tree/master/izia) or via an [online IDE](https://zia-lang.org).
+//! The commands sent are interpreted based on the `Context`. They are used to incrementally modify, test
+//! and debug the `Context`.
 //!
 //! Expressions for Zia commands represent a binary tree where parentheses group a pair of expressions
 //! and a space separates a pair of expressions. For example `"(ll lr) (rl rr)"` represents a perfect
@@ -52,7 +52,7 @@
 //!
 //! // Construct a new `Context` using the `new` method
 //! let mut context = Context::new();
-//! 
+//!
 //! // Specify operator precedence for `let` and `->`.
 //! assert_eq!(context.execute("let default > prec ->"), "");
 //! assert_eq!(context.execute("let (prec ->) > prec let"), "");

--- a/zia/src/lib.rs
+++ b/zia/src/lib.rs
@@ -48,23 +48,29 @@
 //!
 //! // Construct a new `Context` using the `new` method
 //! let mut context = Context::new();
+//! 
+//! // Specify operator precedence for `let` and `->`.
+//! assert_eq!(context.execute("let default > prec ->"), "");
+//! assert_eq!(context.execute("let (prec ->) > prec let"), "");
+//! // Cannot yet infer partial order. Requires implication to express transitive property
+//!  assert_eq!(context.execute("let default > prec let"), "");
 //!
 //! // Specify the rule that the concept "a b" reduces to concept "c"
-//! assert_eq!(context.execute("let (a b) -> c"), "");
+//! assert_eq!(context.execute("let a b -> c"), "");
 //! assert_eq!(context.execute("a b"), "c");
 //!
 //! // Change the rule so that concept "a b" instead reduces to concept "d"
-//! assert_eq!(context.execute("let (a b) -> d"), "");
+//! assert_eq!(context.execute("let a b -> d"), "");
 //! assert_eq!(context.execute("a b"), "d");
 //!
 //! // Change the rule so "a b" doesn't reduce any further
-//! assert_eq!(context.execute("let (a b) -> a b"), "");
+//! assert_eq!(context.execute("let a b -> a b"), "");
 //! assert_eq!(context.execute("a b"), "a b");
 //!
 //! // Try to specify a rule that already exists
-//! assert_eq!(context.execute("let (a b) -> a b"), ZiaError::RedundantReduction.to_string());
-//! assert_eq!(context.execute("let (a b) -> c"), "");
-//! assert_eq!(context.execute("let (a b) -> c"), ZiaError::RedundantReduction.to_string());
+//! assert_eq!(context.execute("let a b -> a b"), ZiaError::RedundantReduction.to_string());
+//! assert_eq!(context.execute("let a b -> c"), "");
+//! assert_eq!(context.execute("let a b -> c"), ZiaError::RedundantReduction.to_string());
 //!
 //! // Relabel "label_of" to "표시"
 //! assert_eq!(context.execute("let 표시 := label_of"), "");
@@ -77,7 +83,7 @@
 //! assert_eq!(context.execute("let b := a b"), ZiaError::InfiniteDefinition.to_string());
 //!
 //! // Try to specify the reduction of concept in terms of itself
-//! assert_eq!(context.execute("let (c d) -> (c d) e"), ZiaError::ExpandingReduction.to_string());
+//! assert_eq!(context.execute("let c d -> (c d) e"), ZiaError::ExpandingReduction.to_string());
 //!
 //! // Determine the truth of a reduction
 //! assert_eq!(context.execute("a -> d"), "true");
@@ -105,7 +111,7 @@
 //! assert_eq!(context.execute("assoc a"), "right");
 //!
 //! // Define patterns
-//! assert_eq!(context.execute("let (_x_ and false) -> false"), "");
+//! assert_eq!(context.execute("let _x_ and false -> false"), "");
 //! assert_eq!(context.execute("foo and false"), "false");
 //! ```
 

--- a/zia/src/lib.rs
+++ b/zia/src/lib.rs
@@ -19,8 +19,9 @@
 //! Instead of storing the source code as plain text and editing the raw text (which can easily break
 //! the program), the runtime environment of the interpreter (the `Context`) can be saved to disk and
 //! used in other programs. All the programming is done using an interactive shell such as
-//! [`IZia`](https://github.com/Charles-Johnson/zia_programming/tree/master/izia). The commands sent are
-//! interpreted based on the `Context`. They are used to incrementally modify, test and debug the `Context`.
+//! [`IZia`](https://github.com/Charles-Johnson/zia_programming/tree/master/izia) or via an online IDE 
+//! (https://zia-lang.org). The commands sent are interpreted based on the `Context`. They are used to
+//! incrementally modify, test and debug the `Context`.
 //!
 //! Expressions for Zia commands represent a binary tree where parentheses group a pair of expressions
 //! and a space separates a pair of expressions. For example `"(ll lr) (rl rr)"` represents a perfect
@@ -53,7 +54,7 @@
 //! assert_eq!(context.execute("let default > prec ->"), "");
 //! assert_eq!(context.execute("let (prec ->) > prec let"), "");
 //! // Cannot yet infer partial order. Requires implication to express transitive property
-//!  assert_eq!(context.execute("let default > prec let"), "");
+//! assert_eq!(context.execute("let default > prec let"), "");
 //!
 //! // Specify the rule that the concept "a b" reduces to concept "c"
 //! assert_eq!(context.execute("let a b -> c"), "");

--- a/zia/src/lib.rs
+++ b/zia/src/lib.rs
@@ -37,7 +37,7 @@
 //! of concepts.
 //!
 //! So far there are 10 built-in concepts. A new `Context` labels these with the symbols, `"label_of"`,
-//! `"->"`, `":="`, `"let"`, `"true"`, `"false"`, `"assoc"`, `"right"`, `"left"`, ">-", "default" but the labels
+//! `"->"`, `":="`, `"let"`, `"true"`, `"false"`, `"assoc"`, `"right"`, `"left"`, "prec", "deafult", ">" but the labels
 //! can be changed to different symbols for different languages or disciplines.
 //!
 //! # Examples
@@ -49,16 +49,8 @@
 //! // Construct a new `Context` using the `new` method
 //! let mut context = Context::new();
 //!
-//! // Let the reduction symbol, "->" have higher operator precedence than
-//! // the "let" symbol
-//! assert_eq!(context.execute("let -> >- let"), "");
-//!
-//! // Make any symbol by default have a higher operator precendence than the
-//! // reduction symbol
-//! assert_eq!(context.execute("let default >- ->"), "");
-//!
 //! // Specify the rule that the concept "a b" reduces to concept "c"
-//! assert_eq!(context.execute("let a b -> c"), "");
+//! assert_eq!(context.execute("let (a b) -> c"), "");
 //! assert_eq!(context.execute("a b"), "c");
 //!
 //! // Change the rule so that concept "a b" instead reduces to concept "d"

--- a/zia/src/lib.rs
+++ b/zia/src/lib.rs
@@ -38,7 +38,7 @@
 //! of concepts.
 //!
 //! So far there are 10 built-in concepts. A new `Context` labels these with the symbols, `"label_of"`,
-//! `"->"`, `":="`, `"let"`, `"true"`, `"false"`, `"assoc"`, `"right"`, `"left"`, ">-", but the labels
+//! `"->"`, `":="`, `"let"`, `"true"`, `"false"`, `"assoc"`, `"right"`, `"left"`, ">-", "default" but the labels
 //! can be changed to different symbols for different languages or disciplines.
 //!
 //! # Examples
@@ -50,8 +50,16 @@
 //! // Construct a new `Context` using the `new` method
 //! let mut context = Context::new();
 //!
+//! // Let the reduction symbol, "->" have higher operator precedence than
+//! // the "let" symbol
+//! assert_eq!(context.execute("let -> >- let"), "");
+//!
+//! // Make any symbol by default have a higher operator precendence than the
+//! // reduction symbol
+//! assert_eq!(context.execute("let default >- ->"), "");
+//!
 //! // Specify the rule that the concept "a b" reduces to concept "c"
-//! assert_eq!(context.execute("let (a b) -> c"), "");
+//! assert_eq!(context.execute("let a b -> c"), "");
 //! assert_eq!(context.execute("a b"), "c");
 //!
 //! // Change the rule so that concept "a b" instead reduces to concept "d"

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -118,11 +118,11 @@ impl SnapShot {
             match cd {
                 ConceptDelta::Insert(_) => {
                     removed_gaps.insert(*id);
-                },
+                }
                 ConceptDelta::Remove(_) => {
                     added_gaps.push(*id);
                     removed_gaps.remove(id);
-                },
+                }
                 ConceptDelta::Update(_) => (),
             }
         }
@@ -141,7 +141,7 @@ impl SnapShot {
                         index = id;
                         break;
                     }
-                },
+                }
                 (None, Some(gi)) => {
                     if removed_gaps.contains(&self.gaps[gi]) {
                         if gi == 0 {
@@ -155,11 +155,11 @@ impl SnapShot {
                         index = self.gaps[gi];
                         break;
                     }
-                },
+                }
                 (None, None) => {
                     index = new_concept_length;
                     break;
-                },
+                }
             };
         }
         (
@@ -287,7 +287,7 @@ impl SnapShot {
                             } else {
                                 Err(ZiaError::AmbiguousExpression)
                             }
-                        },
+                        }
                         (Some(x), None) => Ok(Some(x)),
                         (None, _) => Err(ZiaError::AmbiguousExpression),
                     }
@@ -330,7 +330,7 @@ impl SnapShot {
                             )?;
                             Ok(self.combine(deltas, &head, &tail))
                         }
-                    },
+                    }
                     Some(Associativity::Left) => lp_indices
                         .iter()
                         .try_fold(
@@ -363,7 +363,7 @@ impl SnapShot {
                         .ok_or(ZiaError::AmbiguousExpression),
                     None => Err(ZiaError::AmbiguousExpression),
                 }
-            },
+            }
         }
     }
 
@@ -393,9 +393,9 @@ impl SnapShot {
                             &precedence_of_token,
                         ),
                     );
-                    match dbg!(ContextSearch::from((self, delta))
-                        .recursively_reduce(&dbg!(comparing_between_tokens))
-                        .get_concept())
+                    match ContextSearch::from((self, delta))
+                        .recursively_reduce(&comparing_between_tokens)
+                        .get_concept()
                     {
                         // syntax of token has an even lower precedence than some previous lowest precendence syntax
                         Some(TRUE) => {
@@ -404,7 +404,7 @@ impl SnapShot {
                                 vec![this_index.unwrap()],
                                 this_index,
                             ))
-                        },
+                        }
                         // syntax of token has a higher precedence than some previous lowest precendence syntax
                         Some(FALSE) => {
                             return Ok((
@@ -412,7 +412,7 @@ impl SnapShot {
                                 lp_indices,
                                 this_index,
                             ))
-                        },
+                        }
                         _ => {
                             let comparing_between_tokens_reversed = self
                                 .combine(
@@ -424,11 +424,11 @@ impl SnapShot {
                                         &precedence_of_syntax,
                                     ),
                                 );
-                            match dbg!(ContextSearch::from((self, delta,))
-                                .recursively_reduce(&dbg!(
-                                    comparing_between_tokens_reversed
-                                ),))
-                            .get_concept()
+                            match ContextSearch::from((self, delta))
+                                .recursively_reduce(
+                                    &comparing_between_tokens_reversed,
+                                )
+                                .get_concept()
                             {
                                 // syntax of token has an even lower precedence than some previous lowest precendence syntax
                                 Some(FALSE) => {
@@ -437,7 +437,7 @@ impl SnapShot {
                                         vec![this_index.unwrap()],
                                         this_index,
                                     ))
-                                },
+                                }
                                 // syntax of token has a higher precedence than some previous lowest precendence syntax
                                 Some(TRUE) => {
                                     return Ok((
@@ -445,10 +445,10 @@ impl SnapShot {
                                         lp_indices,
                                         this_index,
                                     ))
-                                },
+                                }
                                 _ => (),
                             };
-                        },
+                        }
                     };
                 }
                 // syntax of token has neither higher or lower precedence than the lowest precedence syntax
@@ -701,7 +701,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                },
+                }
             },
         );
         let right_string = right.get_expansion().map_or_else(
@@ -713,7 +713,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                },
+                }
                 Associativity::Right => l.to_string() + " " + &r.to_string(),
             },
         );
@@ -828,7 +828,7 @@ impl Apply for SnapShot {
                 ..
             } => {
                 self.string_map.insert(s.to_string(), *after);
-            },
+            }
             StringDelta::Insert(id) => self.add_string(*id, s),
             StringDelta::Remove(_) => self.remove_string(s),
         });
@@ -846,13 +846,13 @@ impl Apply for SnapShot {
                         if v {
                             self.variables.insert(id);
                         }
-                    },
+                    }
                     ConceptDelta::Remove(_) => {
                         self.blindly_remove_concept(id);
                         if v {
                             self.variables.remove(&id);
                         }
-                    },
+                    }
                     ConceptDelta::Update(d) => self.write_concept(id).apply(d),
                 }
             }
@@ -894,7 +894,7 @@ fn parse_letter(
         '(' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level + 1)
-        },
+        }
         ')' => {
             if parenthesis_level > 0 {
                 parenthesis_level -= 1;
@@ -905,16 +905,16 @@ fn parse_letter(
                     symbol: "(",
                 })
             }
-        },
+        }
         ' ' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level)
-        },
+        }
         '\n' | '\r' => Ok(parenthesis_level),
         _ => {
             token.push(letter);
             Ok(parenthesis_level)
-        },
+        }
     }
 }
 

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -118,11 +118,11 @@ impl SnapShot {
             match cd {
                 ConceptDelta::Insert(_) => {
                     removed_gaps.insert(*id);
-                }
+                },
                 ConceptDelta::Remove(_) => {
                     added_gaps.push(*id);
                     removed_gaps.remove(id);
-                }
+                },
                 ConceptDelta::Update(_) => (),
             }
         }
@@ -141,7 +141,7 @@ impl SnapShot {
                         index = id;
                         break;
                     }
-                }
+                },
                 (None, Some(gi)) => {
                     if removed_gaps.contains(&self.gaps[gi]) {
                         if gi == 0 {
@@ -155,11 +155,11 @@ impl SnapShot {
                         index = self.gaps[gi];
                         break;
                     }
-                }
+                },
                 (None, None) => {
                     index = new_concept_length;
                     break;
-                }
+                },
             };
         }
         (
@@ -320,7 +320,7 @@ impl SnapShot {
                                             vec![this_index.unwrap()],
                                             this_index,
                                         ))
-                                    }
+                                    },
                                     // syntax of token has a higher precedence than some previous lowest precendence syntax
                                     Some(FALSE) => {
                                         return Ok((
@@ -328,7 +328,7 @@ impl SnapShot {
                                             lp_indices,
                                             this_index,
                                         ))
-                                    }
+                                    },
                                     _ => {
                                         let comparing_between_tokens_reversed =
                                             self.combine(
@@ -355,7 +355,7 @@ impl SnapShot {
                                                     vec![this_index.unwrap()],
                                                     this_index,
                                                 ))
-                                            }
+                                            },
                                             // syntax of token has a higher precedence than some previous lowest precendence syntax
                                             Some(TRUE) => {
                                                 return Ok((
@@ -363,10 +363,10 @@ impl SnapShot {
                                                     lp_indices,
                                                     this_index,
                                                 ))
-                                            }
+                                            },
                                             _ => (),
                                         };
-                                    }
+                                    },
                                 };
                             }
                             // syntax of token has neither higher or lower precedence than the lowest precedence syntax
@@ -388,7 +388,7 @@ impl SnapShot {
                             } else {
                                 Err(ZiaError::AmbiguousExpression)
                             }
-                        }
+                        },
                         (Some(x), None) => Ok(Some(x)),
                         (None, _) => Err(ZiaError::AmbiguousExpression),
                     }
@@ -431,7 +431,7 @@ impl SnapShot {
                             )?;
                             Ok(self.combine(deltas, &head, &tail))
                         }
-                    }
+                    },
                     Some(Associativity::Left) => lp_indices
                         .iter()
                         .try_fold(
@@ -464,7 +464,7 @@ impl SnapShot {
                         .ok_or(ZiaError::AmbiguousExpression),
                     None => Err(ZiaError::AmbiguousExpression),
                 }
-            }
+            },
         }
     }
 
@@ -704,7 +704,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                }
+                },
             },
         );
         let right_string = right.get_expansion().map_or_else(
@@ -716,7 +716,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                }
+                },
                 Associativity::Right => l.to_string() + " " + &r.to_string(),
             },
         );
@@ -831,7 +831,7 @@ impl Apply for SnapShot {
                 ..
             } => {
                 self.string_map.insert(s.to_string(), *after);
-            }
+            },
             StringDelta::Insert(id) => self.add_string(*id, s),
             StringDelta::Remove(_) => self.remove_string(s),
         });
@@ -849,13 +849,13 @@ impl Apply for SnapShot {
                         if v {
                             self.variables.insert(id);
                         }
-                    }
+                    },
                     ConceptDelta::Remove(_) => {
                         self.blindly_remove_concept(id);
                         if v {
                             self.variables.remove(&id);
                         }
-                    }
+                    },
                     ConceptDelta::Update(d) => self.write_concept(id).apply(d),
                 }
             }
@@ -897,7 +897,7 @@ fn parse_letter(
         '(' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level + 1)
-        }
+        },
         ')' => {
             if parenthesis_level > 0 {
                 parenthesis_level -= 1;
@@ -908,16 +908,16 @@ fn parse_letter(
                     symbol: "(",
                 })
             }
-        }
+        },
         ' ' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level)
-        }
+        },
         '\n' | '\r' => Ok(parenthesis_level),
         _ => {
             token.push(letter);
             Ok(parenthesis_level)
-        }
+        },
     }
 }
 

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -28,7 +28,7 @@ use std::{
 };
 
 /// A container for adding, reading, writing and removing concepts of generic type `T`.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct SnapShot {
     /// Relates a String value to the index where the concept corresponding to the String is stored
     /// in the `concepts` field.

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -365,8 +365,7 @@ impl SnapShot {
             Associativity::Right => 0,
         };
         let lp_with_the_rest = if lp_index == edge_index {
-            let edge_syntax =
-                self.ast_from_token(delta, &slice[edge_index])?;
+            let edge_syntax = self.ast_from_token(delta, &slice[edge_index])?;
             if slice.len() == 1 {
                 edge_syntax
             } else {
@@ -413,6 +412,7 @@ impl SnapShot {
             Some(lp_index),
         ))
     }
+
     /// Determine the syntax and the positions in the token sequence of the concepts with the lowest precedence
     fn lowest_precedence_info(
         &self,
@@ -422,9 +422,10 @@ impl SnapShot {
         let precedence_syntax = self.to_ast(delta, PRECEDENCE);
         let greater_than_syntax = self.to_ast(delta, GREATER_THAN);
         let (syntax, positions, _number_of_tokens) = tokens.iter().try_fold(
-            // Initially assume no concepts have the lowest precedence 
+            // Initially assume no concepts have the lowest precedence
             (Vec::<Rc<SyntaxTree>>::new(), Vec::<usize>::new(), None),
-            |(lowest_precedence_syntax, lp_indices, prev_index), token| {
+            |(mut lowest_precedence_syntax, mut lp_indices, prev_index),
+             token| {
                 // Increment index
                 let this_index = prev_index.map(|x| x + 1).or(Some(0));
                 let syntax_of_token = self.ast_from_token(delta, token)?;
@@ -508,11 +509,9 @@ impl SnapShot {
                     };
                 }
                 // syntax of token has neither higher or lower precedence than the lowest precedence syntax
-                let mut lps = lowest_precedence_syntax;
-                lps.push(syntax_of_token);
-                let mut lpi = lp_indices;
-                lpi.push(this_index.unwrap());
-                Ok((lps, lpi, this_index))
+                lowest_precedence_syntax.push(syntax_of_token);
+                lp_indices.push(this_index.unwrap());
+                Ok((lowest_precedence_syntax, lp_indices, this_index))
             },
         )?;
         Ok(TokenSubsequence {

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -304,8 +304,23 @@ impl SnapShot {
                                         Some(i) => &tokens[*lp_index..i],
                                         None => &tokens[*lp_index..],
                                     };
-                                    let lp_with_the_rest =
-                                        self.ast_from_tokens(deltas, slice)?;
+                                    let lp_with_the_rest = if *lp_index == 0 {
+                                        if slice.len() == 1 {
+                                            self.ast_from_token(deltas, &tokens[0])?
+                                        } else {
+                                            self.combine(
+                                                deltas,
+                                                &self.ast_from_token(deltas, &tokens[0])?,
+                                                &if slice.len() < 3 {
+                                                    self.ast_from_token(deltas, &slice[1])?
+                                                } else {
+                                                    self.ast_from_tokens(deltas, &slice[1..])?
+                                                }
+                                            )
+                                        }
+                                    } else {
+                                        self.ast_from_tokens(deltas, slice)?
+                                    };
                                     Ok((
                                         Some(match tail {
                                             None => lp_with_the_rest,

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -118,11 +118,11 @@ impl SnapShot {
             match cd {
                 ConceptDelta::Insert(_) => {
                     removed_gaps.insert(*id);
-                },
+                }
                 ConceptDelta::Remove(_) => {
                     added_gaps.push(*id);
                     removed_gaps.remove(id);
-                },
+                }
                 ConceptDelta::Update(_) => (),
             }
         }
@@ -141,7 +141,7 @@ impl SnapShot {
                         index = id;
                         break;
                     }
-                },
+                }
                 (None, Some(gi)) => {
                     if removed_gaps.contains(&self.gaps[gi]) {
                         if gi == 0 {
@@ -155,11 +155,11 @@ impl SnapShot {
                         index = self.gaps[gi];
                         break;
                     }
-                },
+                }
                 (None, None) => {
                     index = new_concept_length;
                     break;
-                },
+                }
             };
         }
         (
@@ -320,7 +320,7 @@ impl SnapShot {
                                             vec![this_index.unwrap()],
                                             this_index,
                                         ))
-                                    },
+                                    }
                                     // syntax of token has a higher precedence than some previous lowest precendence syntax
                                     Some(FALSE) => {
                                         return Ok((
@@ -328,7 +328,7 @@ impl SnapShot {
                                             lp_indices,
                                             this_index,
                                         ))
-                                    },
+                                    }
                                     _ => {
                                         let comparing_between_tokens_reversed =
                                             self.combine(
@@ -355,7 +355,7 @@ impl SnapShot {
                                                     vec![this_index.unwrap()],
                                                     this_index,
                                                 ))
-                                            },
+                                            }
                                             // syntax of token has a higher precedence than some previous lowest precendence syntax
                                             Some(TRUE) => {
                                                 return Ok((
@@ -363,10 +363,10 @@ impl SnapShot {
                                                     lp_indices,
                                                     this_index,
                                                 ))
-                                            },
+                                            }
                                             _ => (),
                                         };
-                                    },
+                                    }
                                 };
                             }
                             // syntax of token has neither higher or lower precedence than the lowest precedence syntax
@@ -388,7 +388,7 @@ impl SnapShot {
                             } else {
                                 Err(ZiaError::AmbiguousExpression)
                             }
-                        },
+                        }
                         (Some(x), None) => Ok(Some(x)),
                         (None, _) => Err(ZiaError::AmbiguousExpression),
                     }
@@ -422,16 +422,16 @@ impl SnapShot {
                             )?
                             .0
                             .unwrap(); // Already checked that lp_indices is non-empty;
-                        if lp_indices[0] != 0 {
+                        if lp_indices[0] == 0 {
+                            Ok(tail)
+                        } else {
                             let head = self.ast_from_tokens(
                                 deltas,
                                 &tokens[..lp_indices[0]],
                             )?;
                             Ok(self.combine(deltas, &head, &tail))
-                        } else {
-                            Ok(tail)
                         }
-                    },
+                    }
                     Some(Associativity::Left) => lp_indices
                         .iter()
                         .try_fold(
@@ -464,7 +464,7 @@ impl SnapShot {
                         .ok_or(ZiaError::AmbiguousExpression),
                     None => Err(ZiaError::AmbiguousExpression),
                 }
-            },
+            }
         }
     }
 
@@ -704,7 +704,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                },
+                }
             },
         );
         let right_string = right.get_expansion().map_or_else(
@@ -716,7 +716,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                },
+                }
                 Associativity::Right => l.to_string() + " " + &r.to_string(),
             },
         );
@@ -831,7 +831,7 @@ impl Apply for SnapShot {
                 ..
             } => {
                 self.string_map.insert(s.to_string(), *after);
-            },
+            }
             StringDelta::Insert(id) => self.add_string(*id, s),
             StringDelta::Remove(_) => self.remove_string(s),
         });
@@ -849,13 +849,13 @@ impl Apply for SnapShot {
                         if v {
                             self.variables.insert(id);
                         }
-                    },
+                    }
                     ConceptDelta::Remove(_) => {
                         self.blindly_remove_concept(id);
                         if v {
                             self.variables.remove(&id);
                         }
-                    },
+                    }
                     ConceptDelta::Update(d) => self.write_concept(id).apply(d),
                 }
             }
@@ -897,7 +897,7 @@ fn parse_letter(
         '(' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level + 1)
-        },
+        }
         ')' => {
             if parenthesis_level > 0 {
                 parenthesis_level -= 1;
@@ -908,16 +908,16 @@ fn parse_letter(
                     symbol: "(",
                 })
             }
-        },
+        }
         ' ' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level)
-        },
+        }
         '\n' | '\r' => Ok(parenthesis_level),
         _ => {
             token.push(letter);
             Ok(parenthesis_level)
-        },
+        }
     }
 }
 

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -118,11 +118,11 @@ impl SnapShot {
             match cd {
                 ConceptDelta::Insert(_) => {
                     removed_gaps.insert(*id);
-                }
+                },
                 ConceptDelta::Remove(_) => {
                     added_gaps.push(*id);
                     removed_gaps.remove(id);
-                }
+                },
                 ConceptDelta::Update(_) => (),
             }
         }
@@ -141,7 +141,7 @@ impl SnapShot {
                         index = id;
                         break;
                     }
-                }
+                },
                 (None, Some(gi)) => {
                     if removed_gaps.contains(&self.gaps[gi]) {
                         if gi == 0 {
@@ -155,11 +155,11 @@ impl SnapShot {
                         index = self.gaps[gi];
                         break;
                     }
-                }
+                },
                 (None, None) => {
                     index = new_concept_length;
                     break;
-                }
+                },
             };
         }
         (
@@ -320,7 +320,7 @@ impl SnapShot {
                                             vec![this_index.unwrap()],
                                             this_index,
                                         ))
-                                    }
+                                    },
                                     // syntax of token has a higher precedence than some previous lowest precendence syntax
                                     Some(FALSE) => {
                                         return Ok((
@@ -328,7 +328,7 @@ impl SnapShot {
                                             lp_indices,
                                             this_index,
                                         ))
-                                    }
+                                    },
                                     _ => {
                                         let comparing_between_tokens_reversed =
                                             self.combine(
@@ -355,7 +355,7 @@ impl SnapShot {
                                                     vec![this_index.unwrap()],
                                                     this_index,
                                                 ))
-                                            }
+                                            },
                                             // syntax of token has a higher precedence than some previous lowest precendence syntax
                                             Some(TRUE) => {
                                                 return Ok((
@@ -363,10 +363,10 @@ impl SnapShot {
                                                     lp_indices,
                                                     this_index,
                                                 ))
-                                            }
+                                            },
                                             _ => (),
                                         };
-                                    }
+                                    },
                                 };
                             }
                             // syntax of token has neither higher or lower precedence than the lowest precedence syntax
@@ -388,7 +388,7 @@ impl SnapShot {
                             } else {
                                 Err(ZiaError::AmbiguousExpression)
                             }
-                        }
+                        },
                         (Some(x), None) => Ok(Some(x)),
                         (None, _) => Err(ZiaError::AmbiguousExpression),
                     }
@@ -431,7 +431,7 @@ impl SnapShot {
                         } else {
                             Ok(tail)
                         }
-                    }
+                    },
                     Some(Associativity::Left) => lp_indices
                         .iter()
                         .try_fold(
@@ -464,7 +464,7 @@ impl SnapShot {
                         .ok_or(ZiaError::AmbiguousExpression),
                     None => Err(ZiaError::AmbiguousExpression),
                 }
-            }
+            },
         }
     }
 
@@ -656,6 +656,7 @@ impl SnapShot {
             )
         }
     }
+
     pub fn combine(
         &self,
         deltas: &ContextDelta,
@@ -703,7 +704,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                }
+                },
             },
         );
         let right_string = right.get_expansion().map_or_else(
@@ -715,7 +716,7 @@ impl SnapShot {
                         + " "
                         + &r.to_string()
                         + ")"
-                }
+                },
                 Associativity::Right => l.to_string() + " " + &r.to_string(),
             },
         );
@@ -830,7 +831,7 @@ impl Apply for SnapShot {
                 ..
             } => {
                 self.string_map.insert(s.to_string(), *after);
-            }
+            },
             StringDelta::Insert(id) => self.add_string(*id, s),
             StringDelta::Remove(_) => self.remove_string(s),
         });
@@ -848,13 +849,13 @@ impl Apply for SnapShot {
                         if v {
                             self.variables.insert(id);
                         }
-                    }
+                    },
                     ConceptDelta::Remove(_) => {
                         self.blindly_remove_concept(id);
                         if v {
                             self.variables.remove(&id);
                         }
-                    }
+                    },
                     ConceptDelta::Update(d) => self.write_concept(id).apply(d),
                 }
             }
@@ -896,7 +897,7 @@ fn parse_letter(
         '(' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level + 1)
-        }
+        },
         ')' => {
             if parenthesis_level > 0 {
                 parenthesis_level -= 1;
@@ -907,16 +908,16 @@ fn parse_letter(
                     symbol: "(",
                 })
             }
-        }
+        },
         ' ' => {
             push_token(letter, parenthesis_level, token, tokens);
             Ok(parenthesis_level)
-        }
+        },
         '\n' | '\r' => Ok(parenthesis_level),
         _ => {
             token.push(letter);
             Ok(parenthesis_level)
-        }
+        },
     }
 }
 

--- a/zia/tests/definitions_and_reductions.rs
+++ b/zia/tests/definitions_and_reductions.rs
@@ -22,7 +22,7 @@ extern crate zia;
 
 // Needed for assume_abstract macro which is needed for let_definition macro
 use test_zia::CONCRETE_SYMBOLS;
-use zia::{Context, ZiaError};
+use zia::{ZiaError, NEW_CONTEXT};
 
 proptest! {
     #[test]
@@ -38,7 +38,7 @@ proptest! {
         prop_assume!((a != d || b != e) && c != f); // To prevent redundant reduction
         prop_assume!((a != c) || (b != f)); // Without this assumption, (a b) d e -> c is possibly true
         prop_assume!((d != c) || (e != f)); // Without this assumption, (a b) d e -> f is possibly true
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         reduce_pair!(cont, a, b, c);
         reduce_pair!(cont, d, e, f);
         let_definition!(cont, g, c, f);
@@ -53,7 +53,7 @@ proptest! {
     fn sneeky_infinite_reduction_chain(a in "a|b|c|d", b in "a|b|c|d", c in "a|b|c|d", d in "a|b|c|d") {
         assume_abstract!(a);
         assume_symbols!(a, b, c, d);
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         let reduction = format!("let ({} {}) -> {}", c, d, a);
         assert_eq!(cont.execute(&reduction), "");
         let definition = format!("let {} := {} {} {}", a, b, c, d);
@@ -74,7 +74,7 @@ proptest! {
         assume_abstract!(a);
         assume_symbols!(a, b, c, d, e);
         prop_assume!(a != b && a != c && a != d); // To avoid a circular definition
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         let definition = format!("let {} := {} {} {}", a, b, c, d);
         assert_eq!(cont.execute(&definition), "");
         reduce_pair!(cont, c, d, e);

--- a/zia/tests/precedence.proptest-regressions
+++ b/zia/tests/precedence.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 675c9bb5b87560d4b2b2f56a476239861a2560097430e58a3bf0af421c670d36 # shrinks to a = ""

--- a/zia/tests/precedence.rs
+++ b/zia/tests/precedence.rs
@@ -36,7 +36,17 @@ fn set_let_precedence() {
     let mut context = NEW_CONTEXT.clone();
     assert_eq!(context.execute("let default > prec let"), "");
     assert_eq!(context.execute("let a -> b"), "");
-    // assert_eq!(context.execute("a"), "b");
+    assert_eq!(context.execute("a"), "b");
+}
+#[test]
+fn set_reduction_precedence() {
+    let mut context = NEW_CONTEXT.clone();
+    assert_eq!(context.execute("let default > prec ->"), "");
+    assert_eq!(context.execute("let (prec ->) > prec let"), "");
+    // Cannot yet infer partial order. Requires implication to express transitive property
+    assert_eq!(context.execute("let default > prec let"), "");
+    assert_eq!(context.execute("let c d -> e"), "");
+    assert_eq!(context.execute("c d"), "e");
 }
 
 proptest! {

--- a/zia/tests/precedence.rs
+++ b/zia/tests/precedence.rs
@@ -23,6 +23,22 @@ extern crate test_zia;
 use test_zia::CONCRETE_SYMBOLS;
 use zia::NEW_CONTEXT;
 
+#[test]
+fn lower_than_default_precedence() {
+    let mut context = NEW_CONTEXT.clone();
+    assert_eq!(context.execute("let default > prec b"), "");
+    assert_eq!(context.execute("prec b"), "prec b");
+    assert_eq!(context.execute("c d b"), "(c d) b");
+}
+
+#[test]
+fn set_let_precedence() {
+    let mut context = NEW_CONTEXT.clone();
+    assert_eq!(context.execute("let default > prec let"), "");
+    assert_eq!(context.execute("let a -> b"), "");
+    // assert_eq!(context.execute("a"), "b");
+}
+
 proptest! {
     #[test]
     fn default_precedence(a in "\\PC*") {

--- a/zia/tests/precedence.rs
+++ b/zia/tests/precedence.rs
@@ -1,5 +1,5 @@
 //  Library for the Zia programming language.
-// Copyright (C) 2018 to 2019 Charles Johnson
+// Copyright (C) 2020 Charles Johnson
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -13,15 +13,22 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
-pub const LABEL: usize = 0;
-pub const DEFINE: usize = 1;
-pub const REDUCTION: usize = 2;
-pub const LET: usize = 3;
-pub const TRUE: usize = 4;
-pub const FALSE: usize = 5;
-pub const ASSOC: usize = 6;
-pub const RIGHT: usize = 7;
-pub const LEFT: usize = 8;
-pub const PRECEDENCE: usize = 9;
-pub const DEFAULT: usize = 10;
-pub const GREATER_THAN: usize = 11;
+
+#[macro_use]
+extern crate proptest;
+extern crate zia;
+#[macro_use]
+extern crate test_zia;
+
+use test_zia::CONCRETE_SYMBOLS;
+use zia::NEW_CONTEXT;
+
+proptest! {
+    #[test]
+    fn default_precedence(a in "\\PC*") {
+        assume_abstract!(a);
+        assume_symbol!(a);
+        let mut context = NEW_CONTEXT.clone();
+        assert_eq!(context.execute(&format!("prec {}", a)), "default");
+    }
+}

--- a/zia/tests/program_recognition.rs
+++ b/zia/tests/program_recognition.rs
@@ -22,7 +22,7 @@ extern crate zia;
 
 // Needed for assume_abstract macro which is needed for let_definition macro
 use test_zia::CONCRETE_SYMBOLS;
-use zia::Context;
+use zia::NEW_CONTEXT;
 
 proptest! {
     // A previously unused symbol cannot reduce
@@ -30,7 +30,7 @@ proptest! {
     fn fresh_symbol_is_not_a_program(a in "\\PC*") {
         assume_abstract!(a);
         assume_symbol!(a);
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         assert_eq!(cont.execute(&a), a);
     }
     // A pair of previously unused symbols cannot reduce
@@ -39,28 +39,28 @@ proptest! {
         assume_abstract!(a);
         assume_abstract!(b);
         assume_symbols!(a, b);
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         let command = format!("{} {}", a, b);
         assert_eq!(cont.execute(&command), command);
     }
     // An expression of previously unused symbols containing a nested pair cannot reduce
     #[test]
     fn fresh_nested_pair_does_not_reduce(a in "a|b|c", b in "a|b|c", c in "a|b|c") {
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         let command = format!("{} {} {}", a, b, c);
         assert_eq!(cont.execute(&command), command);
     }
     // A previously used symbol cannot reduce unless it is a reducible concepts.
     #[test]
     fn used_symbol_does_not_reduce(a in "a|b|c", b in "a|b|c", c in "a|b|c") {
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         reduce_pair!(cont, a, b, c);
         assert_eq!(cont.execute(&c), c);
     }
     // A pair of previously used symbols cannot reduce unless their concepts are composed of any reducible concepts.
     #[test]
     fn used_symbol_in_a_pair_does_not_reduce(a in "a|b|c", b in "a|b|c", c in "a|b|c") {
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         reduce_pair!(cont, a, b, c);
         prop_assume!(b != c);
         let command = format!("{} {}", a, c);
@@ -75,7 +75,7 @@ proptest! {
     ) {
         assume_abstract!(c);
         prop_assume!((a != b) && (b != c) && (c != a));
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         reduce_pair!(cont, a, b, c);
         let command = format!("{} {} {}", a, b, c);
         assert_eq!(cont.execute(&command), command);

--- a/zia/tests/syntax.rs
+++ b/zia/tests/syntax.rs
@@ -18,17 +18,17 @@
 extern crate proptest;
 extern crate zia;
 
-use zia::{Context, ZiaError};
+use zia::{ZiaError, NEW_CONTEXT};
 
 #[test]
 fn empty_parentheses() {
-    let mut cont = Context::new();
+    let mut cont = NEW_CONTEXT.clone();
     assert_eq!(cont.execute("()"), ZiaError::EmptyParentheses.to_string());
 }
 proptest! {
     #[test]
     fn ambiguous_expression(a in "a|b|c", b in "a|b|c", c in "a|b|c") {
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         assert_eq!(cont.execute(&format!("let (assoc {}) -> left", c)), "");
         assert_eq!(
             cont.execute(&format!("{} {} {}", a, b, c)),
@@ -38,7 +38,7 @@ proptest! {
     // No input should crash the interpreter
     #[test]
     fn random_input(a in "\\PC*") {
-        let mut cont = Context::new();
+        let mut cont = NEW_CONTEXT.clone();
         cont.execute(&a);
     }
 }

--- a/zia/tests/variables.rs
+++ b/zia/tests/variables.rs
@@ -19,19 +19,19 @@
 extern crate proptest;
 extern crate zia;
 
-use zia::Context;
+use zia::NEW_CONTEXT;
 
 proptest! {
     #[test]
     fn single_variable_reduction(a in "a|b|c|d", b in "a|b|c|d", c in "a|b|c|d", d in "a|b|c|d") {
-        let mut context = Context::new();
+        let mut context = NEW_CONTEXT.clone();
         assert_eq!(context.execute(&format!("let (_{}_ {}) -> {}", a, b, c)), "");
         assert_eq!(context.execute(&format!("{} {}", d, b)), c);
     }
     #[test]
     fn repeated_variable_reduction(a in "a|b|c", b in "a|b|c", c in "a|b|c") {
         prop_assume!(b != c);
-        let mut context = Context::new();
+        let mut context = NEW_CONTEXT.clone();
         // Define how a + a can be written as 2 a
         assert_eq!(context.execute(&format!("let (_{0}_ + _{0}_) -> 2 _{0}_", a)), "");
         // Check whether a + b -> 2 a if a = b


### PR DESCRIPTION
`let (prec a) > prec b` means that `a` is paired with the expression to it's left/right when constructing the syntax tree before `b` does given that `a` is left/right associative.

If `prec a` is not a concept then this expression reduces to `default`.

`let default > prec a` can be used to stop `a` pairing with it's neighbour before the other expressions by default. `let (prec a) > default` can be used to stop other expressions from pairing with their neighbours until `a` has by default.

The interpreter cannot infer yet from `let a > b` and `let b > c` that `a > c` because it is required to understand the meaning of implication (`=>`) in the partial order transitivity relation `_x_ > _y_ and _y_ > _z_ => _x_ > _z_`.