### PR TITLE
Improve scrolling

### DIFF
--- a/zia-lang.org/crate/src/lib.rs
+++ b/zia-lang.org/crate/src/lib.rs
@@ -119,11 +119,11 @@ pub fn view(model: &Model) -> impl IntoNodes<Msg> {
             C.flex_col,
             C.font_monospace
         ],
-        page::partial::header::view().into_nodes(),
         match model.page {
             Page::Home => page::home::view(&model.home_page_model).into_nodes(),
             Page::NotFound => page::not_found::view().into_nodes(),
         },
+        page::partial::header::view().into_nodes(),
     ]
 }
 

--- a/zia-lang.org/crate/src/lib.rs
+++ b/zia-lang.org/crate/src/lib.rs
@@ -63,7 +63,7 @@ impl From<Url> for Page {
 fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
     orders
         .subscribe(Msg::UrlChanged)
-        .after_next_render(|_| Msg::FocusOnCommandInput);
+        .after_next_render(|_| Msg::ClearCommandInput);
 
     Model {
         page: url.into(),
@@ -82,7 +82,7 @@ fn init(url: Url, orders: &mut impl Orders<Msg>) -> Model {
 pub enum Msg {
     UrlChanged(subs::UrlChanged),
     Home(home::Msg),
-    FocusOnCommandInput,
+    ClearCommandInput,
 }
 
 pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
@@ -91,8 +91,8 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
             model.page = url.into();
         },
         Msg::Home(hm) => home::update(hm, &mut model.home_page_model, orders),
-        Msg::FocusOnCommandInput => {
-            model.home_page_model.focus_on_command_input();
+        Msg::ClearCommandInput => {
+            model.home_page_model.clear_command_input();
         },
     }
 }

--- a/zia-lang.org/crate/src/page/home/command_input.rs
+++ b/zia-lang.org/crate/src/page/home/command_input.rs
@@ -1,5 +1,5 @@
+use super::{Model as HomeModel, Msg as HomeMsg, EDGE_STYLE, TEXT_PADDING};
 use crate::{generated::css_classes::C, Msg as GlobalMsg};
-use super::{Msg as HomeMsg, EDGE_STYLE, TEXT_PADDING, Model as HomeModel};
 use seed::{attrs, prelude::*, style, textarea, C};
 
 pub fn view(model: &HomeModel) -> impl IntoNodes<GlobalMsg> {

--- a/zia-lang.org/crate/src/page/home/command_input.rs
+++ b/zia-lang.org/crate/src/page/home/command_input.rs
@@ -1,9 +1,20 @@
 use super::{Model as HomeModel, Msg as HomeMsg, EDGE_STYLE, TEXT_PADDING};
-use crate::{generated::css_classes::C, Msg as GlobalMsg};
-use seed::{attrs, prelude::*, style, textarea, C};
+use crate::{
+    generated::css_classes::C, page::home::OUTER_PADDING, Msg as GlobalMsg,
+};
+use seed::{attrs, div, prelude::*, style, textarea, C};
 
 pub fn view(model: &HomeModel) -> impl IntoNodes<GlobalMsg> {
-    textarea![
+    let height = model.command_input.get().map_or_else(
+        // flatten textarea on first render to prevent it being
+        // too tall on subsequent renders
+        || "0".to_owned(),
+        // subsequent renders should set the height just enough to fit the text
+        |e| px(e.scroll_height()),
+    );
+    // prevents bottom part of history being obscured by command input
+    let div = div![style![St::Height => height]];
+    let textarea = textarea![
         C![
             C.border_primary,
             C.border_2,
@@ -13,13 +24,15 @@ pub fn view(model: &HomeModel) -> impl IntoNodes<GlobalMsg> {
             C.overflow_hidden
         ],
         attrs! {At::Type => "text", At::Name => "input"},
-        style! {St::Resize => "none", St::Height => model.command_input.get().map_or_else(
-            // flatten textarea on first render to prevent it being
-            // too tall on subsequent renders
-            || "0".to_owned(),
-            // subsequent renders should set the height just enough to fit the text
-            |e| px(e.scroll_height())
-        )},
+        style! {St::Resize => "none", St::Height => height,
+            St::Position => "fixed",
+            // required to fix the commend input to the bottom of the screen
+            St::Bottom => "0",
+            // without this command input is not horizontally centered
+            St::Left => "0",
+            St::Width => format!("calc(100% - calc(2 * {}))", OUTER_PADDING),
+            St::Margin => OUTER_PADDING
+        },
         el_ref(&model.command_input),
         input_ev(Ev::Input, |s| GlobalMsg::Home(HomeMsg::Input(s))),
         keyboard_ev("keydown", |ev| (ev.key_code() == 13).then(|| {
@@ -29,5 +42,6 @@ pub fn view(model: &HomeModel) -> impl IntoNodes<GlobalMsg> {
             GlobalMsg::Home(HomeMsg::Submit)
         })),
         &model.input
-    ]
+    ];
+    vec![div, textarea]
 }

--- a/zia-lang.org/crate/src/page/home/command_input.rs
+++ b/zia-lang.org/crate/src/page/home/command_input.rs
@@ -1,0 +1,33 @@
+use crate::{generated::css_classes::C, Msg as GlobalMsg};
+use super::{Msg as HomeMsg, EDGE_STYLE, TEXT_PADDING, Model as HomeModel};
+use seed::{attrs, prelude::*, style, textarea, C};
+
+pub fn view(model: &HomeModel) -> impl IntoNodes<GlobalMsg> {
+    textarea![
+        C![
+            C.border_primary,
+            C.border_2,
+            EDGE_STYLE,
+            TEXT_PADDING,
+            C.outline_none,
+            C.overflow_hidden
+        ],
+        attrs! {At::Type => "text", At::Name => "input"},
+        style! {St::Resize => "none", St::Height => model.command_input.get().map_or_else(
+            // flatten textarea on first render to prevent it being
+            // too tall on subsequent renders
+            || "0".to_owned(),
+            // subsequent renders should set the height just enough to fit the text
+            |e| px(e.scroll_height())
+        )},
+        el_ref(&model.command_input),
+        input_ev(Ev::Input, |s| GlobalMsg::Home(HomeMsg::Input(s))),
+        keyboard_ev("keydown", |ev| (ev.key_code() == 13).then(|| {
+            // prevents textarea from retaining the text
+            ev.prevent_default();
+            ev.stop_propagation();
+            GlobalMsg::Home(HomeMsg::Submit)
+        })),
+        &model.input
+    ]
+}

--- a/zia-lang.org/crate/src/page/home/history.rs
+++ b/zia-lang.org/crate/src/page/home/history.rs
@@ -1,0 +1,30 @@
+use super::{EntryKind, Model as HomeModel, EDGE_STYLE, TEXT_PADDING};
+use crate::{generated::css_classes::C, Msg as GlobalMsg};
+use seed::{div, p, prelude::*, style, C};
+
+pub fn view(model: &HomeModel) -> impl IntoNodes<GlobalMsg> {
+    div![
+        C![C.flex, C.flex_col, C.justify_end],
+        model.history.iter().map(|entry| {
+            div![
+                match entry.kind {
+                    EntryKind::Command => C![
+                        C.bg_primary,
+                        C.text_secondary,
+                        C.self_end,
+                        TEXT_PADDING,
+                        EDGE_STYLE
+                    ],
+                    EntryKind::Evaluation => C![
+                        C.text_primary,
+                        C.self_start,
+                        TEXT_PADDING,
+                        EDGE_STYLE
+                    ],
+                },
+                style!{St::MaxWidth => percent(70), St::OverflowWrap => "break-word"},
+                p![&entry.value]
+            ]
+        })
+    ]
+}

--- a/zia-lang.org/crate/src/page/home/mod.rs
+++ b/zia-lang.org/crate/src/page/home/mod.rs
@@ -4,8 +4,8 @@ mod history;
 use std::mem::swap;
 
 use crate::{generated::css_classes::C, Msg as GlobalMsg};
-use seed::{C, div, log, prelude::*};
-use web_sys::{HtmlElement, HtmlTextAreaElement};
+use seed::{div, log, prelude::*, C};
+use web_sys::HtmlTextAreaElement;
 use zia::single_threaded::Context;
 
 pub struct Model {

--- a/zia-lang.org/crate/src/page/home/mod.rs
+++ b/zia-lang.org/crate/src/page/home/mod.rs
@@ -4,7 +4,7 @@ mod history;
 use std::mem::swap;
 
 use crate::{generated::css_classes::C, Msg as GlobalMsg};
-use seed::{div, log, prelude::*, C};
+use seed::{div, log, prelude::*, style, C};
 use web_sys::HtmlTextAreaElement;
 use zia::single_threaded::Context;
 
@@ -77,10 +77,12 @@ pub fn update(
 
 pub static EDGE_STYLE: &str = C.rounded_28px;
 pub static TEXT_PADDING: &str = C.p_2;
+pub static OUTER_PADDING: &str = "1rem";
 
 pub fn view(model: &Model) -> impl IntoNodes<GlobalMsg> {
     div![
-        C![C.flex, C.flex_col, C.flex_1, C.justify_end, C.p_4],
+        C![C.flex, C.flex_col, C.flex_1, C.justify_end],
+        style! {St::Padding => OUTER_PADDING},
         history::view(model).into_nodes(),
         command_input::view(model).into_nodes(),
     ]

--- a/zia-lang.org/crate/src/page/home/mod.rs
+++ b/zia-lang.org/crate/src/page/home/mod.rs
@@ -1,7 +1,9 @@
+mod command_input;
+
 use std::mem::swap;
 
 use crate::{generated::css_classes::C, Msg as GlobalMsg};
-use seed::{attrs, div, p, prelude::*, style, textarea, C};
+use seed::{div, p, prelude::*, style, C};
 use web_sys::HtmlElement;
 use zia::single_threaded::Context;
 
@@ -69,37 +71,10 @@ pub fn update(
     };
 }
 
-static EDGE_STYLE: &str = C.rounded_28px;
-static TEXT_PADDING: &str = C.p_2;
+pub static EDGE_STYLE: &str = C.rounded_28px;
+pub static TEXT_PADDING: &str = C.p_2;
 
 pub fn view(model: &Model) -> impl IntoNodes<GlobalMsg> {
-    let command_input = textarea![
-        C![
-            C.border_primary,
-            C.border_2,
-            EDGE_STYLE,
-            TEXT_PADDING,
-            C.outline_none,
-            C.overflow_hidden
-        ],
-        attrs! {At::Type => "text", At::Name => "input"},
-        style! {St::Resize => "none", St::Height => model.command_input.get().map_or_else(
-            // flatten textarea on first render to prevent it being
-            // too tall on subsequent renders
-            || "0".to_owned(),
-            // subsequent renders should set the height just enough to fit the text
-            |e| px(e.scroll_height())
-        )},
-        el_ref(&model.command_input),
-        input_ev(Ev::Input, |s| GlobalMsg::Home(Msg::Input(s))),
-        keyboard_ev("keydown", |ev| (ev.key_code() == 13).then(|| {
-            // prevents textarea from retaining the text
-            ev.prevent_default();
-            ev.stop_propagation();
-            GlobalMsg::Home(Msg::Submit)
-        })),
-        &model.input
-    ];
     div![
         C![C.flex, C.flex_col, C.flex_1, C.justify_end, C.p_4],
         model.history.iter().map(|entry| {
@@ -123,6 +98,6 @@ pub fn view(model: &Model) -> impl IntoNodes<GlobalMsg> {
                 p![&entry.value]
             ]
         }),
-        command_input,
+        command_input::view(model).into_nodes(),
     ]
 }

--- a/zia-lang.org/crate/src/page/partial/header.rs
+++ b/zia-lang.org/crate/src/page/partial/header.rs
@@ -1,24 +1,21 @@
-use crate::{generated::css_classes::C, image_src, Msg, Page};
-use seed::{a, attrs, header, img, prelude::*, C};
+use crate::{
+    generated::css_classes::C, image_src, page::home::OUTER_PADDING, Msg, Page,
+};
+use seed::{a, attrs, header, img, prelude::*, style, C};
 
 #[allow(clippy::too_many_lines)]
 pub fn view() -> impl IntoNodes<Msg> {
+    let image_class = C![C.h_10, C.w_10];
     header![
-        C![
-            C.mx_8
-            C.flex,
-            C.justify_between,
-            C.items_center,
-            C.h_24,
-            C.p_4
-        ],
+        C![C.flex, C.justify_between, C.items_center, C.h_10],
+        style![St::Position => "fixed", St::Top => "0", St::Left => "0", St::Width => format!("calc(100% - calc(2 * {}))", OUTER_PADDING), St::Margin => OUTER_PADDING],
         // Logo
         a![
             attrs! {
                 At::Href => Page::Home.to_href()
             },
             img![
-                C![C.h_10, C.w_70px,],
+                &image_class,
                 attrs! {
                     At::Src => image_src("zia.svg"),
                 }
@@ -30,7 +27,7 @@ pub fn view() -> impl IntoNodes<Msg> {
                 At::Href => "https://github.com/Charles-Johnson/zia_programming"
             },
             img![
-                C![C.h_10, C.w_70px],
+                &image_class,
                 attrs! {
                     At::Src => image_src("기트헙.svg")
                 },

--- a/zia/src/concepts/trait.rs
+++ b/zia/src/concepts/trait.rs
@@ -18,8 +18,12 @@ use super::{
 
 pub trait Concept: Sized {
     type Id: Copy + Display + Eq + Hash + Debug;
-    type IdPairIterator<'a>: Iterator<Item = (Self::Id, Self::Id)> where Self: 'a;
-    type IdIterator<'a>: Iterator<Item = Self::Id> where Self: 'a;
+    type IdPairIterator<'a>: Iterator<Item = (Self::Id, Self::Id)>
+    where
+        Self: 'a;
+    type IdIterator<'a>: Iterator<Item = Self::Id>
+    where
+        Self: 'a;
     fn id(&self) -> Self::Id;
 
     fn maybe_composition(&self) -> Option<MaybeComposition<Self::Id>>;

--- a/zia/src/concepts/trait.rs
+++ b/zia/src/concepts/trait.rs
@@ -18,8 +18,8 @@ use super::{
 
 pub trait Concept: Sized {
     type Id: Copy + Display + Eq + Hash + Debug;
-    type IdPairIterator<'a>: Iterator<Item = (Self::Id, Self::Id)>;
-    type IdIterator<'a>: Iterator<Item = Self::Id>;
+    type IdPairIterator<'a>: Iterator<Item = (Self::Id, Self::Id)> where Self: 'a;
+    type IdIterator<'a>: Iterator<Item = Self::Id> where Self: 'a;
     fn id(&self) -> Self::Id;
 
     fn maybe_composition(&self) -> Option<MaybeComposition<Self::Id>>;

--- a/zia/src/context_snap_shot/concept.rs
+++ b/zia/src/context_snap_shot/concept.rs
@@ -61,9 +61,14 @@ impl<'a, 'b> From<&'a NewDirectConceptDelta<ConceptId, ConceptId>>
 
 impl<'a> ConceptTrait for Mixed<'a> {
     type Id = ConceptId;
-    type IdIterator<'b> where Self: 'b = Box<dyn Iterator<Item = Self::Id> + 'b>;
-    type IdPairIterator<'b> where Self: 'b =
-        Box<dyn Iterator<Item = (Self::Id, Self::Id)> + 'b>;
+    type IdIterator<'b>
+    where
+        Self: 'b,
+    = Box<dyn Iterator<Item = Self::Id> + 'b>;
+    type IdPairIterator<'b>
+    where
+        Self: 'b,
+    = Box<dyn Iterator<Item = (Self::Id, Self::Id)> + 'b>;
 
     fn id(&self) -> Self::Id {
         match self {

--- a/zia/src/context_snap_shot/concept.rs
+++ b/zia/src/context_snap_shot/concept.rs
@@ -61,8 +61,8 @@ impl<'a, 'b> From<&'a NewDirectConceptDelta<ConceptId, ConceptId>>
 
 impl<'a> ConceptTrait for Mixed<'a> {
     type Id = ConceptId;
-    type IdIterator<'b> = Box<dyn Iterator<Item = Self::Id> + 'b>;
-    type IdPairIterator<'b> =
+    type IdIterator<'b> where Self: 'b = Box<dyn Iterator<Item = Self::Id> + 'b>;
+    type IdPairIterator<'b> where Self: 'b =
         Box<dyn Iterator<Item = (Self::Id, Self::Id)> + 'b>;
 
     fn id(&self) -> Self::Id {

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -37,7 +37,9 @@ where
         + Debug
         + for<'b> From<
             &'b NewDirectConceptDelta<Self::ConceptId, Self::ConceptId>,
-        > where Self: 'a;
+        >
+    where
+        Self: 'a;
     fn get_concept(
         &self,
         concept_id: Self::ConceptId,

--- a/zia/src/snap_shot.rs
+++ b/zia/src/snap_shot.rs
@@ -37,7 +37,7 @@ where
         + Debug
         + for<'b> From<
             &'b NewDirectConceptDelta<Self::ConceptId, Self::ConceptId>,
-        >;
+        > where Self: 'a;
     fn get_concept(
         &self,
         concept_id: Self::ConceptId,


### PR DESCRIPTION
Stick command input to bottom of view port and stick header to top of view port. History can be scrolled without losing command input or header